### PR TITLE
Copy polyglot changelog

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           version=0.0.$GITHUB_RUN_NUMBER
           sed -i "s/0.0.0/$version/g" dist.ini
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
         working-directory: "test"
       - name: Test the action
         uses: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Copy CHANGELOG.md from the polyglot directory, if it exists
 
 ## [1.0.1] - 2023-08-10
 - Moved from `echo ::set-output ...` to `echo ... >> $GITHUB_OUTPUT`

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,13 @@ runs:
     - name: build package
       id: build
       run: |
+        if [[ ! -e CHANGELOG.md ]]
+        then
+           if [[ -e ../CHANGELOG.md ]]
+           then
+              cp ../CHANGELOG.md CHANGELOG.md
+           fi
+        fi
         filename=$(dzil build | tail -2 | head -1 | sed 's/.*writing archive to \(.*\)/\1/')
         echo "filename=$filename" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -14,9 +14,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: sudo apt-get --assume-yes update 
+    - run: sudo apt-get --assume-yes update
       shell: bash
-    - run: sudo apt-get --assume-yes install perl cpanminus
+    - run: sudo apt-get --assume-yes install perl cpanminus libdist-zilla-perl libdist-zilla-plugin-metaprovides-package-perl libdist-zilla-plugin-git-perl
       shell: bash
     - run: perl -v
       shell: bash

--- a/test/dist.ini
+++ b/test/dist.ini
@@ -4,4 +4,11 @@ license = MIT
 version = v0.0.0
 copyright_holder = SmartBear Software
 
-[@Basic]
+[@Filter]
+-bundle=@Basic
+-remove=GatherDir
+
+[Git::GatherDir]
+[GatherFile]
+; explicitly add unversioned files
+filename=CHANGELOG.md


### PR DESCRIPTION
### 🤔 What's changed?

* GitHub action initialization speedup (get more dependencies from Ubuntu instead of "compiling" from CPAN)
* Copy the CHANGELOG.md file from the polyglot directory if there isn't one in the current directory
* Clean up the use of `::set-output` in the execution of test.yaml

### ⚡️ What's your motivation? 

It's common practice for Perl packages to include a changelog. However, as long as the changelog is located outside of the build directory (e.g. perl/), it can't be packaged. Before the GitHub actions setup, the Perl release template would include a step to copy CHANGELOG.md from the parent directory. This change reinstates that approach.

### 🏷️ What kind of change is this?

:bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I don't think any of the other languages work this way. Does this sound like a solid approach (and do we need to do the same thing on more languages?).

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
